### PR TITLE
Updating twitter URL for FOX

### DIFF
--- a/external/trezor-common/defs/ethereum/tokens/tokens/eth/0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d.json
+++ b/external/trezor-common/defs/ethereum/tokens/tokens/eth/0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d.json
@@ -28,7 +28,7 @@
     "reddit": "https://reddit.com/r/shapeshiftio",
     "slack": "",
     "telegram": "",
-    "twitter": "https://twitter.com/ShapeShift_io",
+    "twitter": "https://twitter.com/ShapeShift",
     "youtube": ""
   }
 }


### PR DESCRIPTION
ShapeShift finally got the @shapeshift twitter handle 🎉 

old handle: twitter.com/shapeshift_io
new handle: twitter.com/shapeshift